### PR TITLE
[scripting/assertion.md] fix: add missing backtick around `I.seePageTitle`

### DIFF
--- a/scripting/assertion.md
+++ b/scripting/assertion.md
@@ -11,7 +11,7 @@ If the assertion fail, the command results in an error.
 | [`I.see`](#isee) |  Assert that an text or element is visible |
 | [`I.dontSee`](#idontsee) |  Assert that an text or element is NOT visible |
 | [`I.count`](#icount) |  Assert the number of occurances for a text or element |
-| [`I.seePageTitle](#iseepagetitle) | Assert the title of the current page |
+| [`I.seePageTitle`](#iseepagetitle) | Assert the title of the current page |
 
 ---
 


### PR DESCRIPTION
## Before
_screenshot of published docs_
![image](https://user-images.githubusercontent.com/4142577/152845777-0206af60-46ab-4fb5-a4d5-c94e4ed07145.png)

## After
_screenshot of fixed markdown file_
![image](https://user-images.githubusercontent.com/4142577/152845919-61111ba2-74a2-4d56-94c0-2f24adc2fe23.png)
